### PR TITLE
Adding ProductDiff case to handleResult, raises error for now.

### DIFF
--- a/src/war/War/Interface/Controller.hs
+++ b/src/war/War/Interface/Controller.hs
@@ -135,6 +135,7 @@ handleResult config gang chainsTotal result
         let status
              = case product' of
                  ProductStatus s _ -> s
+                 ProductDiff _ _ _ -> error "handleResult: ProductDiff case unimplemented"
 
         let prefix'     = configSuppressPrefix config
         let width'      = configFormatPathWidth config


### PR DESCRIPTION
```
src/war/War/Interface/Controller.hs:136:16: warning: [-Wincomplete-patterns]
    Pattern match(es) are non-exhaustive
    In a case alternative: Patterns not matched: (ProductDiff _ _ _)
    |
136 |              = case product' of
    |                ^^^^^^^^^^^^^^^^...

<no location info>: error: 
Failing due to -Werror.
```