### PR TITLE
trivial: upgrade parsec to fix ci

### DIFF
--- a/make/target/setup.mk
+++ b/make/target/setup.mk
@@ -14,7 +14,7 @@ setup :
 		text mtl stm json \
 		happy-1.19.9
 	@$(DEPS_INSTALLER) v1-install \
-		parsec-3.1.13.0 \
+		parsec-3.1.14.0 \
 		inchworm-1.1.1.2 \
 		buildbox-2.2.1.2 \
 		hedgehog-0.6.1


### PR DESCRIPTION
I'm just creating this as a PR to check that it does fix the build before merging it to master.

The Travis build failed to install Parsec because a newer version was
already installed. Might as well just try the newer version.